### PR TITLE
Project structure

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -30,6 +30,9 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
       <component name="FacetManager">
         <facet type="scala" name="Scala">
           <configuration>
+            {
+              project.basePackage.map(bp => <option name="basePackage" value={bp} />).getOrElse(scala.xml.Null)
+            }
             <option name="compilerLibraryLevel" value="Project" />
             <option name="compilerLibraryName" value={ "scala-" + project.scalaInstance.version } />
           </configuration>

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -22,7 +22,7 @@ case class Directories(sources: Seq[File], resources: Seq[File], outDir: File)
 
 case class SubProjectInfo(baseDir: File, name: String, dependencyProjects: List[String], compileDirs: Directories,
                           testDirs: Directories, libraries: Seq[IdeaModuleLibRef], scalaInstance: ScalaInstance,
-                          ideaGroup: Option[String], webAppPath: Option[File])
+                          ideaGroup: Option[String], webAppPath: Option[File], basePackage: Option[String])
 
 case class IdeaProjectInfo(baseDir: File, name: String, childProjects: List[SubProjectInfo], ideaLibs: List[IdeaLibrary])
 

--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -10,19 +10,114 @@ object SbtIdeaModuleMapping {
       instance.extraJars.filter(_.getAbsolutePath.endsWith("-sources.jar")))
   }
 
+  /**
+   * Extracts IDEA libraries from the keys:
+   *
+   *   * `externalDependencyClasspath`
+   *   * `update`
+   *   * `updateClassifiers`
+   *   * `updateSbtClassifiers`
+   *   * `unmanagedClasspath`
+   */
+  final class LibrariesExtractor(buildStruct: Load.BuildStructure, state: State, projectRef: ProjectRef, logger: Logger,
+                           scalaInstance: ScalaInstance, withClassifiers: Boolean, withSbtClassifiers: Boolean) {
+
+    def allLibraries: Seq[IdeaModuleLibRef] = managedLibraries ++ unmanagedLibraries
+
+    /**
+     * Creates an IDEA library entry for each entry in `externalDependencyClasspath` in `Test` and `Compile.
+     *
+     * The result of `update`, `updateClassfiers`, and `updateSbtClassfiers` is used to find the
+     * location on disk of the library, by default in $HOME/.ivy2/cache
+     */
+    def managedLibraries: Seq[IdeaModuleLibRef] = {
+      val deps = evaluateTask(Keys.externalDependencyClasspath in Configurations.Test) match {
+        case Some(Value(deps)) => deps
+        case _ => logger.error("Failed to obtain dependency classpath"); throw new IllegalArgumentException()
+      }
+      val libraries: Seq[(IdeaModuleLibRef, ModuleID)] = evaluateTask(Keys.update) match {
+
+        case Some(Value(report)) =>
+          val libraries: Seq[(IdeaModuleLibRef, ModuleID)] = convertDeps(report, deps, scalaInstance.version)
+
+          val librariesWithClassifiers = {
+            if (withClassifiers) {
+              evaluateTask(Keys.updateClassifiers) match {
+                case Some(Value(report)) => addClassifiers(libraries, report)
+                case _ => libraries
+              }
+            }
+            else libraries
+          }
+
+          if (withSbtClassifiers) {
+            evaluateTask(Keys.updateSbtClassifiers) match {
+              case Some(Value(report)) => addClassifiers(librariesWithClassifiers, report)
+              case _ => librariesWithClassifiers
+            }
+          }
+          else librariesWithClassifiers
+
+        case _ => Seq.empty
+      }
+
+      libraries.map(_._1)
+    }
+
+    /**
+     * Creates an IDEA library entry for each entry in `unmanagedClasspath` in `Test` and `Compile.
+     *
+     * If the entry is both in the compile and test scopes, it is only added to the compile scope.
+     *
+     * source and javadoc JARs are detected according to the Maven naming convention. They are *not*
+     * added to the classpath, but rather associated with the corresponding binary JAR.
+     **/
+    def unmanagedLibraries: Seq[IdeaModuleLibRef] = {
+      def unmanagedLibrariesFor(config: Configuration): Seq[IdeaModuleLibRef] = {
+        evaluateTask(Keys.unmanagedClasspath in config) match {
+          case Some(Value(unmanagedClassPathSeq)) =>
+            /** Uses naming convention to look for an artifact with `classifier` in the same directory as `orig`. */
+            def classifier(orig: File, classifier: String): Option[File] = file(orig.getAbsolutePath.replace(".jar", "-%s.jar".format(classifier))) match {
+              case x if x.exists => Some(x)
+              case _ => None
+            }
+            for {
+              attributedFile <- unmanagedClassPathSeq
+              f = attributedFile.data
+              if Seq("sources", "javadoc").forall(classifier => !f.name.endsWith("-%s.jar".format(classifier)))
+              scope = toScope(config.name)
+              sources = classifier(f, "sources").toSeq
+              javadocs = classifier(f, "javadoc").toSeq
+              ideaLib = IdeaLibrary(f.getName, classes = Seq(f), sources = sources, javaDocs = javadocs)
+            } yield IdeaModuleLibRef(scope, ideaLib)
+          case _ => Seq()
+        }
+      }
+
+      val compileUnmanagedLibraries = unmanagedLibrariesFor(Configurations.Compile)
+      val testUnmanagedLibraries = unmanagedLibrariesFor(Configurations.Test).filterNot(libRef => compileUnmanagedLibraries.exists(_.library == libRef.library))
+      compileUnmanagedLibraries ++ testUnmanagedLibraries
+    }
+
+    private def evaluateTask[T](taskKey : sbt.Project.ScopedKey[sbt.Task[T]]) =
+      EvaluateTask.evaluateTask(buildStruct, taskKey, state, projectRef, false, EvaluateTask.SystemProcessors)
+  }
+
   private def equivModule(m1: ModuleID, m2: ModuleID, scalaVersion: String) = {
-    def name(m: ModuleID): String =
-      if (m.crossVersion) m.name + "_" + scalaVersion else m.name
+    def name(m: ModuleID): String = if (m.crossVersion) m.name + "_" + scalaVersion else m.name
 
     m1.organization == m2.organization && name(m1) == name(m2)
   }
 
   private def ideaLibFromModule(moduleReport: ModuleReport) = {
     val module = moduleReport.module
+    def findByClassifier(classifier: Option[String]) = moduleReport.artifacts.collect {
+      case (artifact, file) if (artifact.classifier == classifier) => file
+    }
     IdeaLibrary(module.organization + "_" + module.name + "_" + module.revision,
-      classes = moduleReport.artifacts.collect{ case (artifact, file) if (artifact.classifier == None) => file },
-      javaDocs = moduleReport.artifacts.collect{ case (artifact, file) if (artifact.classifier == Some("javadoc")) => file },
-      sources = moduleReport.artifacts.collect{ case (artifact, file) if (artifact.classifier == Some("sources")) => file })
+      classes = findByClassifier(None),
+      javaDocs = findByClassifier(Some("javadoc")),
+      sources = findByClassifier(Some("sources")))
   }
 
   private def toScope(conf: String) = {
@@ -40,7 +135,7 @@ object SbtIdeaModuleMapping {
     val scope = toScope(configuration)
     val depFilter = libDepFilter(deps) _
 
-    modules.filter(modReport => depFilter(modReport)).map( moduleReport => {
+    modules.filter(modReport => depFilter(modReport)).map(moduleReport => {
       (IdeaModuleLibRef(scope, ideaLibFromModule(moduleReport)), moduleReport.module)
     })
   }
@@ -49,15 +144,19 @@ object SbtIdeaModuleMapping {
     deps.files.exists(dep => moduleReport.artifacts.exists(_._2 == dep))
   }
 
-  def convertDeps(report: UpdateReport, deps: Keys.Classpath, scalaVersion: String): Seq[(IdeaModuleLibRef, ModuleID)] = {
-    Seq("compile", "runtime", "test", "provided").flatMap(report.configuration).foldLeft(Seq[(IdeaModuleLibRef, ModuleID)]()) { (acc, configReport) =>
-      val filteredModules = configReport.modules.filterNot(m1 =>
-        acc.exists { case (_, m2) => equivModule(m1.module, m2, scalaVersion) })
-      acc ++ mapToIdeaModuleLibs(configReport.configuration, filteredModules, deps)
+  private def convertDeps(report: UpdateReport, deps: Keys.Classpath, scalaVersion: String): Seq[(IdeaModuleLibRef, ModuleID)] = {
+    Seq("compile", "runtime", "test", "provided").flatMap(report.configuration).foldLeft(Seq[(IdeaModuleLibRef, ModuleID)]()) {
+      (acc, configReport) =>
+        val filteredModules = configReport.modules.filterNot(m1 =>
+          acc.exists {
+            case (_, m2) => equivModule(m1.module, m2, scalaVersion)
+          })
+        acc ++ mapToIdeaModuleLibs(configReport.configuration, filteredModules, deps)
     }
   }
 
-  def addClassifiers(ideaModuleLibRefs: Seq[(IdeaModuleLibRef, ModuleID)], report: UpdateReport): Seq[(IdeaModuleLibRef, ModuleID)] = {
+  private def addClassifiers(ideaModuleLibRefs: Seq[(IdeaModuleLibRef, ModuleID)],
+                             report: UpdateReport): Seq[(IdeaModuleLibRef, ModuleID)] = {
 
     /* Both retrieved from UpdateTask, so we don't need to deal with crossVersion here */
     def equivModule(m1: ModuleID, m2: ModuleID): Boolean =
@@ -65,29 +164,36 @@ object SbtIdeaModuleMapping {
 
     val modifiedModuleLibRefs = {
 
-      report.configurations.flatMap { configReport =>
-          
-        configReport.modules.flatMap { moduleReport =>
+      report.configurations.flatMap {
+        configReport =>
 
-          ideaModuleLibRefs.find { case (moduleLibRef, moduleId) =>
-            moduleLibRef.config == toScope(configReport.configuration) && equivModule(moduleReport.module, moduleId)
-          } map { case (moduleLibRef, moduleId) =>
+          configReport.modules.flatMap {
+            moduleReport =>
 
-            val ideaLibrary = {
-              val il = ideaLibFromModule(moduleReport)
-              il.copy(classes = il.classes ++ moduleLibRef.library.classes,
+              ideaModuleLibRefs.find {
+                case (moduleLibRef, moduleId) =>
+                  moduleLibRef.config == toScope(configReport.configuration) && equivModule(moduleReport.module, moduleId)
+              } map {
+                case (moduleLibRef, moduleId) =>
+
+                  val ideaLibrary = {
+                    val il = ideaLibFromModule(moduleReport)
+                    il.copy(classes = il.classes ++ moduleLibRef.library.classes,
                       javaDocs = il.javaDocs ++ moduleLibRef.library.javaDocs,
                       sources = il.sources ++ moduleLibRef.library.sources)
-            }
+                  }
 
-            moduleLibRef.copy(library = ideaLibrary) -> moduleId
+                  moduleLibRef.copy(library = ideaLibrary) -> moduleId
+              }
           }
-        }
       }
     }
 
-    val unmodifiedModuleLibRefs = ideaModuleLibRefs.filterNot { case (_, m1) =>
-      modifiedModuleLibRefs.exists { case (_, m2) => equivModule(m1, m2) }
+    val unmodifiedModuleLibRefs = ideaModuleLibRefs.filterNot {
+      case (_, m1) =>
+        modifiedModuleLibRefs.exists {
+          case (_, m2) => equivModule(m1, m2)
+        }
     }
 
     modifiedModuleLibRefs ++ unmodifiedModuleLibRefs

--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -162,7 +162,7 @@ object SbtIdeaModuleMapping {
 
               ideaModuleLibRefs.find {
                 case (moduleLibRef, moduleId) =>
-                  moduleLibRef.config == toScope(configReport.configuration) && equivModule(moduleReport.module, moduleId)
+                  (moduleLibRef.config == toScope(configReport.configuration) || configReport.configuration == "default") && equivModule(moduleReport.module, moduleId)
               } map {
                 case (moduleLibRef, moduleId) =>
 

--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -15,7 +15,9 @@ object SbtIdeaPlugin extends Plugin {
   val ideaProjectGroup = SettingKey[String]("idea-project-group")
   val sbtScalaInstance = SettingKey[ScalaInstance]("sbt-scala-instance")
   val ideaIgnoreModule = SettingKey[Boolean]("idea-ignore-module")
-  override lazy val settings = Seq(Keys.commands += ideaCommand, ideaProjectName := "IdeaProject")
+  val ideaBasePackage = SettingKey[Option[String]]("idea-base-package", "The base package configured in the Scala Facet, used by IDEA to generated nested package clauses. For example, com.acme.wibble")
+
+  override lazy val settings = Seq(Keys.commands += ideaCommand, ideaProjectName := "IdeaProject", ideaBasePackage := None)
 
   private val WithClassifiers = "with-classifiers"
   private val WithSbtClassifiers = "with-sbt-classifiers"
@@ -153,8 +155,9 @@ object SbtIdeaPlugin extends Plugin {
       logger(state), scalaInstance,
       withClassifiers = args.contains(WithClassifiers)
     )
+    val basePackage = setting(ideaBasePackage, "missing IDEA base package")
     SubProjectInfo(baseDirectory, projectName, project.uses.map(_.project).toList, compileDirectories,
-      testDirectories, librariesExtractor.allLibraries, scalaInstance, ideaGroup, None)
+      testDirectories, librariesExtractor.allLibraries, scalaInstance, ideaGroup, None, basePackage)
   }
 
 }

--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -75,7 +75,7 @@ object SbtIdeaPlugin extends Plugin {
       module.save()
     }
 
-    // Run the `update-classifiers` task to download and find the path of the SBT sources.
+    // Run the `update-sbt-classifiers` task to download and find the path of the SBT sources.
     // See https://github.com/harrah/xsbt/issues/88 for a problem with this in SBT 0.10.0
     //
     // Workaround is to add this resolver to your build (or, temporarily, to your build session).


### PR DESCRIPTION
Tweaks to the IntelliJ module structure to more faithfully reflect the SBT build.
1. Use the project id, rather than name, as the IDEA project name. (By default, they are the same.) This necessarily matches the project reference used in the inter module dependencies.
2. Add the module base directory as a source directory if it contains .scala files, as is done by the default SBT build.

With these changes, gen-idea does a better job at importing the build of SBT itself.
