### PR TITLE
Place Javadoc archive locations within the <javadoc> tag

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -72,10 +72,11 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
           })
           }
         </CLASSES>
-        <JAVADOC />
+        <JAVADOC>
         {
         library.javaDocs.map(file => <root url={String.format("jar://%s!/", projectRelative(file))} />)
         }
+        </JAVADOC>
         <SOURCES>
           {
           library.sources.map(file => {


### PR DESCRIPTION
In the latest version, library configuration files (like .idea/libraries/com_amazonaws_aws_java_sdk_1_2_2.xml) have their JAR files declared outside of the &lt;javadoc&gt; tag. This prevent's IDEA's external documentation feature from finding the javadocs.

This small change fixes the typo. I've confirmed that this works with IDEA 10.5.1.

Thanks!
