### PR TITLE
Set Default File Encoding to UTF-8

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -117,7 +117,8 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
 
       Seq(
         "modules.xml" -> Some(project(projectModuleManagerComponent)),
-        "misc.xml" -> miscXml(configDir).map(miscTransformer.transform).map(_.head)
+        "misc.xml" -> miscXml(configDir).map(miscTransformer.transform).map(_.head),
+        "encodings.xml" -> Some(defaultEncodingsXml)
       ) foreach { 
         case (fileName, Some(xmlNode)) => saveFile(configDir, fileName, xmlNode) 
         case _ =>
@@ -137,6 +138,13 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
     } else log.error("Skipping .idea creation for " + projectInfo.baseDir + " since directory does not exist")
   }
 
+  val defaultEncodingsXml =
+    <project version="4">
+      <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" defaultCharsetForPropertiesFiles="ISO-8859-1">
+        <file url="PROJECT" charset="UTF-8" />
+      </component>
+    </project>
+  
   val defaultMiscXml = <project version="4"> {projectRootManagerComponent} </project>
 
   private def miscXml(configDir: File): Option[Node] = try {


### PR DESCRIPTION
- Set encoding of properties to ISO-8859-1 for legacy support
- Generate .idea/encodings.xml to support this
