### PR TITLE
Add info about configuring plugin within project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 Installation
 ------------
 
-Add the following lines to ~/.sbt/plugins/build.sbt:
+Add the following lines to ~/.sbt/plugins/build.sbt or PROJECT_DIR/project/plugins/build.sbt
 
     resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
     


### PR DESCRIPTION
Configuring under PROJECT_DIR/project/plugins/build.sbt works, but
wasn't previously mentioned in the readme.
