### PR TITLE
Allow excluded.folders to be set to nothing

### DIFF
--- a/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
+++ b/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
@@ -64,9 +64,13 @@ class IdeaModuleDescriptor(val project: BasicDependencyProject, val log: Logger)
             }
           }
           {
-            env.excludedFolders.value.split(",").toList.map(_.trim).sort(_ < _).map { entry =>
-              log.info(String.format("Excluding folder %s\n", entry))
-              <excludeFolder url={String.format("file://$MODULE_DIR$/%s", entry)} />
+            env.excludedFolders.value.split(",").toList.map(_.trim).sort(_ < _).flatMap { entry =>
+              if (entry.equals("")) {
+                None
+              } else {
+                log.info(String.format("Excluding folder %s\n", entry))
+                Some(<excludeFolder url={String.format("file://$MODULE_DIR$/%s", entry)} />)
+              }
             }
           }
         </content>


### PR DESCRIPTION
If excluded.folders is set to nothing, do not add any excluded folders. In our projects we need target/gen-java to be included as source. The directory contains thrift generated source code.
