### PR TITLE
fix: no sources were being generated for the `sbt-and-plugins` library

### DIFF
--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -187,7 +187,7 @@ object SbtIdeaModuleMapping {
       configReport =>
         configReport.modules.map {
           moduleReport =>
-            ideaLibFromModule(moduleReport)
+            ideaLibFromModule(moduleReport, Some(Seq("sources"), Seq("javadoc")))
         }
     }
   }


### PR DESCRIPTION
Issue #97 was the cause, that no source attachments were generated for the `sbt-and-plugins` library. This fixes this problem.
