### PR TITLE
Use Java Version to set Project SDK (fix #146)

### DIFF
--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -58,7 +58,9 @@ object SbtIdeaPlugin extends Plugin {
 
     val projectInfo = IdeaProjectInfo(buildUnit.localBase, name.getOrElse("Unknown"), subProjects, ideaLibs ::: scalaLibs)
 
-    val env = IdeaProjectEnvironment(projectJdkName = "1.6", javaLanguageLevel = "JDK_1_6",
+    val jdkName = System.getProperty("java.version").substring(0,3)
+    val languageLevel = "JDK_" + jdkName.replace(".", "_")
+    val env = IdeaProjectEnvironment(projectJdkName = jdkName, javaLanguageLevel = languageLevel,
       includeSbtProjectDefinitionModule = true, projectOutputPath = None, excludedFolders = "target",
       compileWithIdea = false, modulePath = Some(".idea_modules"))
 


### PR DESCRIPTION
Hi Mikko:

I have a fix for the issue I reported.

Instead of statically using 1.6 as the Project SDK name and JDK_1_6 as the
Project Language Level, use the major and minor from the java.version System
Property of the JVM running SBT.

This won't work in all cases, but it seems like a sensible default.

I am happy to do further testing or code cleanup if you desire :)

Best,
Alain
