### PR TITLE
additional compiler options populated from scalacOptions

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -43,6 +43,7 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
             {
               if (env.scalacOptions.contains("-unchecked")) <option name="uncheckedWarnings" value="true" />
             }
+            <option name="compilerOptions" value={ env.scalacOptions.mkString(" ") } />
           </configuration>
         </facet>
         { if (project.webAppPath.isDefined && userEnv.webFacet == true) webFacet() else scala.xml.Null }


### PR DESCRIPTION
adds <option name="compilerOptions" value="{scalacOptions separated by a space}" /> to the scala facet xml

we use -Ydependent-method-types and have to refresh the 'Additional Compiler Options:' field every time we run gen-idea
