### PR TITLE
Allow test dependency versions to override runtime dependencies

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -178,8 +178,6 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
       .map(_._2.toSeq)
       .flatMap(libs => libs.find(_.config == IdeaLibrary.TestScope).map(testLib => testLib -> libs.filterNot(_ == testLib)))
 
-    evictions.map(e => e._1.library.id -> e._2.map(_.library.id)).map(e => println(e))
-
     evictions.foldLeft(libraries){(libs, e) =>
       val (evictor, evictees) = e
       val evictorIndex = libs.indexOf(evictor)

--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -173,10 +173,11 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
    * detecting evictors, and moving them up in the classpath to just before the evictees.
    */
   def promoteTestEvictors(libraries: Seq[IdeaModuleLibRef]) = {
-    val evictions = libraries.groupBy(_.library.evictionId)
-      .filter(_._2.size > 1)
-      .map(_._2.toSeq)
-      .flatMap(libs => libs.find(_.config == IdeaLibrary.TestScope).map(testLib => testLib -> libs.filterNot(_ == testLib)))
+    val evictions = for {
+      (evictionId, libs) <- libraries.groupBy(_.library.evictionId) if libs.size > 1
+      testLib <- libs.find(_.config == IdeaLibrary.TestScope)
+    } yield
+      testLib -> libs.filterNot(_ == testLib)
 
     evictions.foldLeft(libraries){(libs, e) =>
       val (evictor, evictees) = e

--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -106,7 +106,7 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
         <orderEntry type="sourceFolder" forTests="false"/>
         {
         // what about j.extraAttributes.get("e:docUrl")?
-        project.libraries.map(ref => {
+        promoteTestEvictors(project.libraries).map(ref => {
           val orderEntry = <orderEntry type="library" name={ ref.library.name } level="project"/>
           ref.config match {
                 case IdeaLibrary.CompileScope => orderEntry
@@ -164,5 +164,31 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
         </webroots>
       </configuration>
     </facet>
+  }
+
+  /**
+   * SBT allows different versions of the same library in different scopes, evicting runtime/compile dependencies
+   * out of their scopes if a newer one is found in test when compiling/running tests, while still maintaining
+   * the order as defined in the build configuration. IDEA doesn't support this eviction.  We fake it by
+   * detecting evictors, and moving them up in the classpath to just before the evictees.
+   */
+  def promoteTestEvictors(libraries: Seq[IdeaModuleLibRef]) = {
+    val evictions = libraries.groupBy(_.library.evictionId)
+      .filter(_._2.size > 1)
+      .map(_._2.toSeq)
+      .flatMap(libs => libs.find(_.config == IdeaLibrary.TestScope).map(testLib => testLib -> libs.filterNot(_ == testLib)))
+
+    evictions.map(e => e._1.library.id -> e._2.map(_.library.id)).map(e => println(e))
+
+    evictions.foldLeft(libraries){(libs, e) =>
+      val (evictor, evictees) = e
+      val evictorIndex = libs.indexOf(evictor)
+      val firstEvicteeIndex = libs.indexWhere(l => evictees.contains(l))
+      if (evictorIndex > firstEvicteeIndex) {
+        (libs.take(firstEvicteeIndex) :+ evictor) ++ libs.takeRight(libs.size - firstEvicteeIndex).filterNot(_ == evictor)
+      } else {
+        libs
+      }
+    }
   }
 }

--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -138,7 +138,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
       librariesDir.mkdirs
       for (ideaLib <- projectInfo.ideaLibs) {
         // MUST all be _
-        val filename = ideaLib.name.replace('.', '_').replace('-', '_') + ".xml"
+        val filename = ideaLib.id.replace('.', '_').replace('-', '_') + ".xml"
         saveFile(librariesDir, filename, libraryTableComponent(ideaLib))
       }
 

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -16,7 +16,7 @@ object IdeaLibrary {
   case object ProvidedScope extends Scope("PROVIDED")
 }
 
-case class IdeaLibrary(name: String, classes: Set[File], javaDocs: Set[File], sources: Set[File]) {
+case class IdeaLibrary(id: String, name: String, evictionId: String, classes: Set[File], javaDocs: Set[File], sources: Set[File]) {
   def hasClasses = !classes.isEmpty
   def allFiles = classes ++ sources ++ javaDocs
 }

--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -10,7 +10,8 @@ object SbtIdeaModuleMapping {
     val coreJars = instance.jars.filter { jar =>
       Seq("compiler", "library", "reflect").map("scala-%s.jar" format _).exists(_ == jar.getName)
     }.toSet
-    IdeaLibrary("scala-" + instance.version, coreJars,
+    val id = "scala-" + instance.version
+    IdeaLibrary(id, "Scala " + instance.version, id, coreJars,
       instance.extraJars.filter(_.getAbsolutePath.endsWith("docs.jar")).toSet,
       instance.extraJars.filter(_.getAbsolutePath.endsWith("-sources.jar")).toSet)
   }
@@ -83,7 +84,7 @@ object SbtIdeaModuleMapping {
               scope = toScope(config.name)
               sources = if (f.name.endsWith(".jar")) classifier(f, "sources").toSet else Set[File]()
               javadocs = if (f.name.endsWith(".jar")) classifier(f, "javadoc").toSet else Set[File]()
-              ideaLib = IdeaLibrary(f.getName, classes = Set(f), sources = sources, javaDocs = javadocs)
+              ideaLib = IdeaLibrary(f.getName, f.getName, f.getName, classes = Set(f), sources = sources, javaDocs = javadocs)
             } yield IdeaModuleLibRef(scope, ideaLib)
           case _ => Seq()
         }
@@ -121,12 +122,16 @@ object SbtIdeaModuleMapping {
       case Some(classifiers) => classifiers.foldLeft(Seq[File]()) { (acc, classifier) => acc ++ findByClassifier(Some(classifier)) }
       case None => Seq[File]()
     }
-    val name = module.organization + "_" + module.name + "_" + module.revision + (if (!configuration.isEmpty) "_" + configuration else "")
-      IdeaLibrary(name,
-        classes = findClasses.toSet,
-        sources = findByClassifiers(classifiers.map(_._1)).toSet,
-        javaDocs = findByClassifiers(classifiers.map(_._2)).toSet
-      )
+    val id = module.organization + "_" + module.name + "_" + module.revision + (if (!configuration.isEmpty) "_" + configuration else "")
+    val name = "SBT: " + module.organization + ":" + module.name + ":" + module.revision
+    val artifactId = module.organization + ":" + module.name
+    IdeaLibrary(id,
+      name,
+      artifactId,
+      classes = findClasses.toSet,
+      sources = findByClassifiers(classifiers.map(_._1)).toSet,
+      javaDocs = findByClassifiers(classifiers.map(_._2)).toSet
+    )
   }
 
   private def toScope(conf: String) = {


### PR DESCRIPTION
IDEA and SBT treat dependency scopes fundamentally differently.  In IDEA, there is  a single classpath, and dependencies are either included or not included in it, depending on the current scope.  In SBT, each scope may "evict" dependencies out of the classpath.

For example, if I have dependency in the runtime scope on com.foo:bar:1.1, and then I have a test dependency that transitively depends on com.foo:bar:1.2, then in my runtime scope in SBT, I will have com.foo:bar:1.1, while in test, that will be evicted, and I'll have com.foo:bar:1.2.  For a comparison with other build tools, in Maven for example, the behaviour here is that the test transitive dependency will result in the runtime dependency being upgraded to 1.2, while maintaining its runtime scope.

The way that SBT IDEA currently handles this is that it puts both dependencies on the classpath in the order declared in the build file.  If the test scoped dependency appears later in the buid file, this will cause issues, because 1.1 will come before 1.2, and so it will be found first, so if the transitive test dependency actually uses new features from 1.2, you'll get linkage errors when you run the tests in IDEA, where you won't in SBT.

A naive approach to solving this (that I tried) is to just put all test dependencies before runtime dependencies.  However, this causes another issue, it means the classpath is now in a completely different order to what SBT uses.  In my specific case, another test dependency was bringing a dependency that had changed its groupId, and my runtime scope was depending on the newer version with a different groupId.  In SBT, both dependencies were on the classpath, but since the test dependency was declared later in the classpath, the correct, newer dependency was being used, so it wasn't a problem.  But with in IDEA it was.

So, I've implemented an approach that as closely as possible simulates what SBT does.  It detects when SBT would evict a runtime dependency and replace it with a test dependency, and in that case, moves just that dependency to be just before the runtime dependency in the classpath.  The result is that the classpath order is almost the same as what SBT uses, but not quite in the case of these "evicted" dependencies.  There are still some edge cases where this could cause problems, but I think they would be very rare, if they ever did happen, and I don't think it's possible to 100% emulate SBTs behaviour in IDEA since they have fundamentally different notions of the capabilities of scopes.

Also included in this pull request is a nicer format for the name of the dependencies.  Instead of being named:

com_foo_bar_bar_1.2.3_test

They are now named:

SBT: com.foo.bar:bar:1.2.3

This matches how IDEA handles Maven dependencies, and looks much cleaner.  The old semantics for the filenames are still used.
