### PR TITLE
Made scala facet optional

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -27,25 +27,7 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
   def content: Node = {
     <module type="JAVA_MODULE" version="4">
       <component name="FacetManager">
-        <facet type="scala" name="Scala">
-          <configuration>
-            {
-              project.basePackage.map(bp => <option name="basePackage" value={bp} />).getOrElse(scala.xml.Null)
-            }
-            <option name="compilerLibraryLevel" value="Project" />
-            <option name="compilerLibraryName" value={ "scala-" + project.scalaInstance.version } />
-            {
-              if (env.useProjectFsc) <option name="fsc" value="true" />
-            }
-            {
-              if (project.scalacOptions.contains("-deprecation")) <option name="deprecationWarnings" value="true" />
-            }
-            {
-              if (project.scalacOptions.contains("-unchecked")) <option name="uncheckedWarnings" value="true" />
-            }
-            <option name="compilerOptions" value={ project.scalacOptions.mkString(" ") } />
-          </configuration>
-        </facet>
+        { if (project.includeScalaFacet) scalaFacet else scala.xml.Null }
         { if (project.webAppPath.isDefined && userEnv.webFacet == true) webFacet() else scala.xml.Null }
         { project.extraFacets }
       </component>
@@ -151,6 +133,28 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
     <sourceFolder url={"file://" + path}
                   isTestSource={isTestSourceFolder.toString}
                   packagePrefix={pkg} />
+  }
+
+  def scalaFacet: Node = {
+    <facet type="scala" name="Scala">
+      <configuration>
+        {
+          project.basePackage.map(bp => <option name="basePackage" value={bp} />).getOrElse(scala.xml.Null)
+        }
+        <option name="compilerLibraryLevel" value="Project" />
+        <option name="compilerLibraryName" value={ "scala-" + project.scalaInstance.version } />
+        {
+          if (env.useProjectFsc) <option name="fsc" value="true" />
+        }
+        {
+          if (project.scalacOptions.contains("-deprecation")) <option name="deprecationWarnings" value="true" />
+        }
+        {
+          if (project.scalacOptions.contains("-unchecked")) <option name="uncheckedWarnings" value="true" />
+        }
+        <option name="compilerOptions" value={ project.scalacOptions.mkString(" ") } />
+      </configuration>
+    </facet>
   }
 
   def webFacet(): Node = {

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -31,7 +31,8 @@ case class Directories(sources: Seq[File], resources: Seq[File], outDir: File) {
 case class SubProjectInfo(baseDir: File, name: String, dependencyProjects: List[String], classpathDeps: Seq[(File, Seq[File])], compileDirs: Directories,
                           testDirs: Directories, libraries: Seq[IdeaModuleLibRef], scalaInstance: ScalaInstance,
                           ideaGroup: Option[String], webAppPath: Option[File], basePackage: Option[String],
-                          packagePrefix: Option[String], extraFacets: NodeSeq, scalacOptions: Seq[String])
+                          packagePrefix: Option[String], extraFacets: NodeSeq, scalacOptions: Seq[String],
+                          includeScalaFacet: Boolean)
 
 case class IdeaProjectInfo(baseDir: File, name: String, childProjects: List[SubProjectInfo], ideaLibs: List[IdeaLibrary])
 

--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -20,6 +20,7 @@ object SbtIdeaPlugin extends Plugin {
   val ideaSourcesClassifiers = SettingKey[Seq[String]]("idea-sources-classifiers")
   val ideaJavadocsClassifiers = SettingKey[Seq[String]]("idea-javadocs-classifiers")
   val ideaExtraFacets = SettingKey[NodeSeq]("idea-extra-facets")
+  val ideaIncludeScalaFacet = SettingKey[Boolean]("idea-include-scala-facet")
 
   override lazy val settings = Seq(
     Keys.commands += ideaCommand,
@@ -28,7 +29,8 @@ object SbtIdeaPlugin extends Plugin {
     ideaPackagePrefix := None,
     ideaSourcesClassifiers := Seq("sources"),
     ideaJavadocsClassifiers := Seq("javadoc"),
-    ideaExtraFacets := NodeSeq.Empty
+    ideaExtraFacets := NodeSeq.Empty,
+    ideaIncludeScalaFacet := true
   )
 
   private val NoClassifiers = "no-classifiers"
@@ -227,6 +229,7 @@ object SbtIdeaPlugin extends Plugin {
     val basePackage = setting(ideaBasePackage, "missing IDEA base package")
     val packagePrefix = setting(ideaPackagePrefix, "missing package prefix")
     val extraFacets = settingWithDefault(ideaExtraFacets, NodeSeq.Empty)
+    val includeScalaFacet = settingWithDefault(ideaIncludeScalaFacet, true)
     def isAggregate(p: String) = allProjectIds.toSeq.contains(p)
     val classpathDeps = project.dependencies.filterNot(d => isAggregate(d.project.project)).flatMap { dep =>
       Seq(Compile, Test) map { scope =>
@@ -240,7 +243,8 @@ object SbtIdeaPlugin extends Plugin {
     }
 
     SubProjectInfo(baseDirectory, projectName, project.uses.map(_.project).filter(isAggregate).toList, classpathDeps, compileDirectories,
-      testDirectories, librariesExtractor.allLibraries, scalaInstance, ideaGroup, None, basePackage, packagePrefix, extraFacets, scalacOptions)
+      testDirectories, librariesExtractor.allLibraries, scalaInstance, ideaGroup, None, basePackage, packagePrefix, extraFacets, scalacOptions,
+      includeScalaFacet)
   }
 
 }


### PR DESCRIPTION
Not all SBT projects are necessarily Scala projects.  A good example is a Play Java project, it uses SBT, but will not necessarily have any Scala code in it, and hence the Scala facet shouldn't be added to the module, since the user probably hasn't even installed and doesn't need the Scala plugin in IDEA.

This pull requests makes the scala facet optional, enabled by default via a configuration option.
