### PR TITLE
Fixed bug where windows file separator will lead to PatternSyntaxExcepti...

### DIFF
--- a/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
+++ b/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
@@ -115,7 +115,11 @@ class IdeaModuleDescriptor(val project: BasicDependencyProject, val log: Logger)
           val allJars = projectJars(project)
           // exclude dependencies already declared in module dependencies within the same scope
           def nameWithScope(f: File): String = {
-            f.getAbsolutePath.split(File.separator).reverse.take(2).reverse.toList.mkString(File.separator)
+            val separator = File.separator match {
+              case """\""" => "\\\\"
+              case _ => File.separator
+            }
+            f.getAbsolutePath.split(separator).reverse.take(2).reverse.toList.mkString(separator)
           }
           val alreadyDeclared = dependencyProjects.flatMap{
             case p: BasicDependencyProject => List(projectJars(p).getFiles.map(f => (nameWithScope(f), f.length)))

--- a/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
+++ b/sbt-idea-core/src/main/scala/IdeaModuleDescriptor.scala
@@ -115,11 +115,7 @@ class IdeaModuleDescriptor(val project: BasicDependencyProject, val log: Logger)
           val allJars = projectJars(project)
           // exclude dependencies already declared in module dependencies within the same scope
           def nameWithScope(f: File): String = {
-            val separator = File.separator match {
-              case """\""" => "\\\\"
-              case _ => File.separator
-            }
-            f.getAbsolutePath.split(separator).reverse.take(2).reverse.toList.mkString(separator)
+            f.getAbsolutePath.split(File.separatorChar).reverse.take(2).reverse.toList.mkString(File.separator)
           }
           val alreadyDeclared = dependencyProjects.flatMap{
             case p: BasicDependencyProject => List(projectJars(p).getFiles.map(f => (nameWithScope(f), f.length)))


### PR DESCRIPTION
Only Windows is affected due its standard File.separator = '\' which will lead to a PatternSyntaxException in the String.split() method.

Note: This is only a quick fix I made to have the idea task working again.
