### PR TITLE
Set language level according to scala version used by the module (#195)

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaModuleDescriptor.scala
@@ -145,6 +145,8 @@ class IdeaModuleDescriptor(val imlDir: File, projectRoot: File, val project: Sub
         }
         <option name="compilerLibraryLevel" value="Project" />
         <option name="compilerLibraryName" value={ SbtIdeaModuleMapping.toIdeaLib(project.scalaInstance).name } />
+        <option name="languageLevel" value={project.languageLevel}/>
+
         {
           if (env.useProjectFsc) <option name="fsc" value="true" />
         }

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -33,7 +33,14 @@ case class SubProjectInfo(baseDir: File, name: String, dependencyProjects: List[
                           testDirs: Directories, libraries: Seq[IdeaModuleLibRef], scalaInstance: ScalaInstance,
                           ideaGroup: Option[String], webAppPath: Option[File], basePackage: Option[String],
                           packagePrefix: Option[String], extraFacets: NodeSeq, scalacOptions: Seq[String],
-                          includeScalaFacet: Boolean, androidSupport: AndroidSupport)
+                          includeScalaFacet: Boolean, androidSupport: AndroidSupport) {
+  lazy val languageLevel: String = {
+    val version = scalaInstance.version
+    val binaryScalaVersion = version.take(version.lastIndexOf('.'))
+    val virtualized = if (version.contains("virtualized")) " virtualized" else ""
+    "Scala " + binaryScalaVersion + virtualized
+  }
+}
 
 case class IdeaProjectInfo(baseDir: File, name: String, childProjects: List[SubProjectInfo], ideaLibs: List[IdeaLibrary])
 

--- a/src/sbt-test/sbt-idea/dependency-with-classifier/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/dependency-with-classifier/.idea_modules/main.iml.expected
@@ -4,6 +4,7 @@
       <configuration>
         <option name="compilerLibraryLevel" value="Project"></option>
         <option name="compilerLibraryName" value="SBT: scala:2.9.2"></option>
+        <option name="languageLevel" value="Scala 2.9" />
         <option name="fsc" value="true" />
         <option name="compilerOptions" value="" />
       </configuration>

--- a/src/sbt-test/sbt-idea/external-rootproject-dependency/.idea_modules/dependency-root.iml.expected
+++ b/src/sbt-test/sbt-idea/external-rootproject-dependency/.idea_modules/dependency-root.iml.expected
@@ -4,6 +4,7 @@
      <configuration>
        <option value="Project" name="compilerLibraryLevel"></option>
        <option value="SBT: scala:2.9.2" name="compilerLibraryName"></option>
+       <option value="Scala 2.9" name="languageLevel"></option>
        <option value="true" name="fsc"></option>
        <option value="true" name="deprecationWarnings"></option>
        <option value="-deprecation" name="compilerOptions"/>

--- a/src/sbt-test/sbt-idea/external-rootproject-dependency/.idea_modules/root-project.iml.expected
+++ b/src/sbt-test/sbt-idea/external-rootproject-dependency/.idea_modules/root-project.iml.expected
@@ -4,6 +4,7 @@
      <configuration>
        <option value="Project" name="compilerLibraryLevel"></option>
        <option value="SBT: scala:2.9.2" name="compilerLibraryName"></option>
+       <option value="Scala 2.9" name="languageLevel"></option>
        <option value="true" name="fsc"></option>
        <option value="true" name="uncheckedWarnings"></option>
        <option value="-unchecked" name="compilerOptions"></option>

--- a/src/sbt-test/sbt-idea/simple-project/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/simple-project/.idea_modules/main.iml.expected
@@ -4,6 +4,7 @@
       <configuration>
         <option name="compilerLibraryLevel" value="Project"></option>
         <option name="compilerLibraryName" value="SBT: scala:2.9.2"></option>
+        <option name="languageLevel" value="Scala 2.9" />
         <option name="fsc" value="true" />
         <option name="deprecationWarnings" value="true" />
         <option name="uncheckedWarnings" value="true" />

--- a/src/sbt-test/sbt-idea/with-integration-tests/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/with-integration-tests/.idea_modules/main.iml.expected
@@ -4,6 +4,7 @@
       <configuration>
         <option name="compilerLibraryLevel" value="Project"></option>
         <option name="compilerLibraryName" value="SBT: scala:2.9.2"></option>
+        <option name="languageLevel" value="Scala 2.9" />
         <option name="fsc" value="true" />
         <option name="compilerOptions" value=""/>
       </configuration>


### PR DESCRIPTION
Hey Mikko,
This implements #195.
Although I haven't tested it with IDEA 11 (don't have one now), the new tag should not cause any problems, b/c IDEA usually ignores unknown tags.
As always I'm open to feedback.
Thanks
~
Eugene
