### PR TITLE
Fix configuration order

### DIFF
--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -170,7 +170,7 @@ object SbtIdeaModuleMapping {
     //mapToIdeaModuleLibs and remove the hardcoded configurations. Something like the following would be enough:
     //report.configurations.flatMap(configReport => mapToIdeaModuleLibs(configReport.configuration, configReport.modules, deps))
 
-    Seq("compile", "provided", "test", "runtime", "optional").flatMap(report.configuration(_)).foldLeft(Seq[(IdeaModuleLibRef, ModuleID)]()) {
+    Seq("compile", "provided", "runtime", "test", "optional").flatMap(report.configuration(_)).foldLeft(Seq[(IdeaModuleLibRef, ModuleID)]()) {
       (acc, configReport) =>
         def processedArtifacts = acc.flatMap(_._1.library.allFiles)
         def alreadyIncludedJar(f: File): Boolean = { processedArtifacts.exists(_.getAbsolutePath == f.getAbsolutePath) }

--- a/src/sbt-test/sbt-idea/simple-project/.idea/libraries/SBT__mysql_mysql_connector_java_5_1_25_runtime.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project/.idea/libraries/SBT__mysql_mysql_connector_java_5_1_25_runtime.xml.expected
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="SBT: mysql:mysql-connector-java:5.1.25:runtime">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/mysql/mysql-connector-java/jars/mysql-connector-java-5.1.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/src/sbt-test/sbt-idea/simple-project/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/simple-project/.idea_modules/main.iml.expected
@@ -37,6 +37,7 @@
     <orderEntry level="project" name="SBT: org.scala-lang:scala-library:2.9.2" type="library"></orderEntry>
     <orderEntry level="project" name="SBT: junit:junit:4.8.2" type="library"></orderEntry>
     <orderEntry scope="PROVIDED" level="project" name="SBT: javax.servlet:servlet-api:2.5:provided" type="library"></orderEntry>
+    <orderEntry scope="RUNTIME" level="project" name="SBT: mysql:mysql-connector-java:5.1.25:runtime" type="library"></orderEntry>
     <orderEntry scope="TEST" level="project" name="SBT: org.eclipse.jetty:jetty-server:7.0.0.v20091005:test" type="library"></orderEntry>
     <orderEntry scope="TEST" level="project" name="SBT: org.eclipse.jetty:jetty-continuation:7.0.0.v20091005:test" type="library"></orderEntry>
     <orderEntry scope="TEST" level="project" name="SBT: org.eclipse.jetty:jetty-http:7.0.0.v20091005:test" type="library"></orderEntry>

--- a/src/sbt-test/sbt-idea/simple-project/project/Build.scala
+++ b/src/sbt-test/sbt-idea/simple-project/project/Build.scala
@@ -17,6 +17,7 @@ object ScriptedTestBuild extends AbstractScriptedTestBuild("simple-project") {
   lazy val dependencies = Seq(
     "junit" % "junit" % "4.8.2",
     "org.eclipse.jetty" % "jetty-server" % "7.0.0.v20091005" % "test",
-    "javax.servlet" % "servlet-api" % "2.5" % "provided"
+    "javax.servlet" % "servlet-api" % "2.5" % "provided",
+    "mysql" % "mysql-connector-java" % "5.1.25" % "runtime"
   )
 }


### PR DESCRIPTION
I added a runtime dependency, but gen-idea generated test scope library.

Runtime scope should be prioritized than Test one.
See: https://github.com/sbt/sbt/blob/v0.12.3/ivy/IvyInterface.scala#L421-L426
