### PR TITLE
Fix compiler library in SBT 0.13.x with Scala != 2.10.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 libraryDependencies <+= sbtVersion("org.scala-sbt" % "scripted-plugin" % _)
 

--- a/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaModuleMapping.scala
@@ -8,7 +8,7 @@ object SbtIdeaModuleMapping {
 
   def toIdeaLib(instance: ScalaInstance) = {
     val coreJars = instance.jars.filter { jar =>
-      Seq("compiler", "library", "reflect").map("scala-%s.jar" format _).exists(_ == jar.getName)
+      Seq("compiler", "library", "reflect").exists(x => jar.getName.contains(x))
     }.toSet
     val id = "scala-" + instance.version
     IdeaLibrary(id, "SBT: scala:" + instance.version, id, coreJars,

--- a/src/sbt-test/sbt-idea/dependency-with-classifier/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/dependency-with-classifier/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")

--- a/src/sbt-test/sbt-idea/external-rootproject-dependency/dependency-project/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/external-rootproject-dependency/dependency-project/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
 

--- a/src/sbt-test/sbt-idea/external-rootproject-dependency/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/external-rootproject-dependency/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
 

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/IdeaProject.iml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/IdeaProject.iml.expected
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4" >
+  <component inherit-compiler-output="true" name="NewModuleRootManager">
+    <exclude-output></exclude-output>
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/target"></excludeFolder>
+    </content>
+    <orderEntry type="inheritedJdk"></orderEntry>
+    <orderEntry type="sourceFolder" forTests="false"></orderEntry>
+  </component>
+ </module>
+
+

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/highlighting.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/highlighting.xml.expected
@@ -1,0 +1,6 @@
+<project version="4">
+  <component name="HighlightingAdvisor">
+    <option name="SUGGEST_TYPE_AWARE_HIGHLIGHTING" value="false"/>
+    <option name="TYPE_AWARE_HIGHLIGHTING_ENABLED" value="true"/>
+  </component>
+</project>

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/libraries/SBT__scala_2_10_2.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/libraries/SBT__scala_2_10_2.xml.expected
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="SBT: scala:2.10.2">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/global/boot/scala-2.10.2/lib/scala-library.jar!/"></root>
+      <root url="jar://$PROJECT_DIR$/global/boot/scala-2.10.2/lib/scala-compiler.jar!/"></root>
+      <root url="jar://$PROJECT_DIR$/global/boot/scala-2.10.2/lib/scala-reflect.jar!/"></root>
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/libraries/SBT__scala_2_10_3.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/libraries/SBT__scala_2_10_3.xml.expected
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+ <library name="SBT: scala:2.10.3">
+   <CLASSES>
+     <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.10.3.jar!/"/>
+     <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.10.3.jar!/"/>
+     <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.10.3.jar!/"/>
+   </CLASSES>
+   <JAVADOC/>
+   <SOURCES/>
+ </library>
+</component>

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/misc.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/misc.xml.expected
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component languageLevel="JDK_1_6" assert-keyword="true" project-jdk-name="1.6" name="ProjectRootManager" project-jdk-type="JavaSDK" jdk-15="true" version="2">
+    <output url="file://$PROJECT_DIR$/target/idea_output"></output>
+  </component>
+</project>
+

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/modules.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/modules.xml.expected
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea_modules/main-build.iml" filepath="$PROJECT_DIR$/.idea_modules/main-build.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea_modules/main.iml" filepath="$PROJECT_DIR$/.idea_modules/main.iml" />
+    </modules>
+  </component>
+</project>
+

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/scala_compiler.xml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea/scala_compiler.xml.expected
@@ -1,0 +1,6 @@
+<project version="4">
+  <component name="ScalacSettings">
+    <option name="COMPILER_LIBRARY_NAME" value="SBT: scala:2.10.3"></option>
+    <option name="COMPILER_LIBRARY_LEVEL" value="Project"></option>
+  </component>
+</project>

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/.idea_modules/main.iml.expected
@@ -1,0 +1,30 @@
+ <module version="4" type="JAVA_MODULE">
+  <component name="FacetManager">
+    <facet name="Scala" type="scala">
+      <configuration>
+        <option value="Project" name="compilerLibraryLevel"/>
+        <option value="SBT: scala:2.10.3" name="compilerLibraryName"/>
+        <option value="Scala 2.10" name="languageLevel"/>
+        <option value="true" name="fsc"/>
+        <option value="" name="compilerOptions"/>
+      </configuration>
+    </facet>
+  </component>
+  <component inherit-compiler-output="false" name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/../target/scala-2.10/classes"/>
+    <output-test url="file://$MODULE_DIR$/../target/scala-2.10/test-classes"/>
+    <exclude-output/>
+    <content url="file://$MODULE_DIR$/../">
+      <sourceFolder isTestSource="false" url="file://$MODULE_DIR$/../src/main/scala"/>
+      <sourceFolder isTestSource="false" url="file://$MODULE_DIR$/../src/main/java"/>
+      <sourceFolder isTestSource="false" url="file://$MODULE_DIR$/../src/main/resources"/>
+      <sourceFolder isTestSource="true" url="file://$MODULE_DIR$/../src/test/scala"/>
+      <sourceFolder isTestSource="true" url="file://$MODULE_DIR$/../src/test/java"/>
+      <sourceFolder isTestSource="true" url="file://$MODULE_DIR$/../src/test/resources"/>
+      <excludeFolder url="file://$MODULE_DIR$/../target"/>
+    </content>
+    <orderEntry type="inheritedJdk"/>
+    <orderEntry forTests="false" type="sourceFolder"/>
+    <orderEntry level="project" name="SBT: org.scala-lang:scala-library:2.10.3" type="library"/>
+  </component>
+</module>

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/README.txt
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/README.txt
@@ -1,0 +1,2 @@
+This project has a different version of Scala to SBT 0.13.0, which
+triggers bug #248.

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/project/Build.scala
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/project/Build.scala
@@ -1,0 +1,11 @@
+import org.sbtidea.test.util.AbstractScriptedTestBuild
+import sbt._
+import sbt.Keys._
+import org.sbtidea.SbtIdeaPlugin._
+
+object ScriptedTestBuild extends AbstractScriptedTestBuild("simple-project") {
+
+  lazy val root = Project("main", file("."), settings = Defaults.defaultSettings ++ scriptedTestSettings ++ Seq(
+    scalaVersion := "2.10.3"
+  ))
+}

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
+

--- a/src/sbt-test/sbt-idea/simple-project-2.10.3/test
+++ b/src/sbt-test/sbt-idea/simple-project-2.10.3/test
@@ -1,0 +1,2 @@
+> gen-idea
+> assert-expected-xml-files

--- a/src/sbt-test/sbt-idea/simple-project/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/simple-project/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
 

--- a/src/sbt-test/sbt-idea/with-integration-tests/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/with-integration-tests/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
 


### PR DESCRIPTION
Before 0.13.0, we _always_ used to get JARs from the boot directory; now we
only seem to get these if we use the same Scala version as SBT itself (2.10.2).

This commit relaxes the filtering to handle both naming conventions.

Fixes #248
