### PR TITLE
IDEA source dirs for generated sources (#251)

### DIFF
--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -170,8 +170,9 @@ object SbtIdeaPlugin extends Plugin {
         state.log.info("Running " + config.name + ":" + Keys.managedSources.key.label + " ...")
         EvaluateTask(buildStruct, Keys.managedSources in config, state, projectRef)
         val managedSourceRoots = settings.setting(Keys.managedSourceDirectories in config, "Missing managed source directories!")
+        val sourceManaged = settings.setting(Keys.sourceManaged in config, "Missing 'sourceManaged'")
         def listSubdirectories(f: File) = Option(f.listFiles()).map(_.toSeq.filter(_.isDirectory)).getOrElse(Seq.empty[File])
-        managedSourceRoots.flatMap(listSubdirectories)
+        (listSubdirectories(sourceManaged) ++ managedSourceRoots).distinct
       }
       else Seq.empty[File]
 


### PR DESCRIPTION
Instead of subdirs of all `managedSourceDirectories`, use subdirs of `sourceManaged` as well as `managedSourceDirectories` themselves

As I said in conclusion of the discussion at #252, I'd like to submit a different fix for #251.

This time around, source roots include:
- the subdirectories of `sourceManaged` (in the considered config), which I think is more in line with the sbt doc at http://www.scala-sbt.org/release/docs/Howto/generatefiles.html than adding all the subdirs of all `managedSourceDirectories`, event though the latter setting is initially a list containing only `sourceManaged`.
- as well as the directories in the `managedSourceDirectories` list. Even though the doc for that setting could be seen as ambiguous ("Managed source directories, which contain sources generated by the build."), I still think it reasonable to expect that a directory added to `managedSourceDirectories` (either by a plugin or directly in a build) be a compile root. Going through a handful of codegen plugins, I saw only one (sbt-protobuf) that adds anything to `managedSourceDirectories`, and it is indeed a compile root that is added.

I've tested this fix with the project that originally prompted me to raise the issue (which uses sbt-protobuf and sbt-buildinfo), as well as with the sample project given with issue #209, and I find it to be working as expected in both cases.
