### PR TITLE
delete existing xml files for libraries unless dont-delete-existing-libs argument is specified

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -129,6 +129,10 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
 
       val librariesDir = configFile("libraries")
       librariesDir.mkdirs
+      if (env.deleteExistingLibraries) {
+        IO.delete(IO.listFiles(librariesDir, GlobFilter("SBT__*.xml")))
+        log.info("Deleted existing library files")
+      }
       for (ideaLib <- projectInfo.ideaLibs) {
         // MUST all be _
         val filename = ideaLib.name.replaceAll("[:\\.\\s-]", "_") + ".xml"

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -49,4 +49,4 @@ case class IdeaUserEnvironment(webFacet: Boolean)
 case class IdeaProjectEnvironment(projectJdkName :String, javaLanguageLevel: String,
                                   includeSbtProjectDefinitionModule: Boolean, projectOutputPath: Option[String],
                                   excludedFolders: Seq[String], compileWithIdea: Boolean, modulePath: String, useProjectFsc: Boolean,
-                                  enableTypeHighlighting: Boolean)
+                                  enableTypeHighlighting: Boolean, deleteExistingLibraries: Boolean)

--- a/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/SBT__javax_servlet_servlet_api_2_5_provided.xml
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/SBT__javax_servlet_servlet_api_2_5_provided.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="SBT: javax.servlet:servlet-api:2.5:provided">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/javax.servlet/servlet-api/jars/servlet-api-2.5.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/javax.servlet/servlet-api/srcs/servlet-api-2.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/SBT__junit_junit_4_8_2.xml.expected
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/SBT__junit_junit_4_8_2.xml.expected
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="SBT: junit:junit:4.8.2">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.8.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/docs/junit-4.8.2-javadoc.jar!/"></root>
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/srcs/junit-4.8.2-sources.jar!/"></root>
+    </SOURCES>
+  </library>
+</component>

--- a/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/mysql_mysql_connector_java_5_1_25_runtime.xml
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/.idea/libraries/mysql_mysql_connector_java_5_1_25_runtime.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="mysql:mysql-connector-java:5.1.25:runtime">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.ivy2/cache/mysql/mysql-connector-java/jars/mysql-connector-java-5.1.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/src/sbt-test/sbt-idea/delete-existing-libs/project/Build.scala
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/project/Build.scala
@@ -1,0 +1,15 @@
+import org.sbtidea.test.util.AbstractScriptedTestBuild
+import sbt._
+import sbt.Keys._
+
+object ScriptedTestBuild extends AbstractScriptedTestBuild("simple-project") {
+
+  lazy val root = Project("main", file("."),
+    settings = Defaults.defaultSettings ++
+      scriptedTestSettings ++ Seq(libraryDependencies ++= dependencies)
+  )
+
+  lazy val dependencies = Seq(
+    "junit" % "junit" % "4.8.2"
+  )
+}

--- a/src/sbt-test/sbt-idea/delete-existing-libs/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0-SNAPSHOT")
+

--- a/src/sbt-test/sbt-idea/delete-existing-libs/test
+++ b/src/sbt-test/sbt-idea/delete-existing-libs/test
@@ -1,0 +1,11 @@
+$ exists .idea/libraries/mysql_mysql_connector_java_5_1_25_runtime.xml
+$ exists .idea/libraries/SBT__javax_servlet_servlet_api_2_5_provided.xml
+$ exists .idea/libraries/SBT__junit_junit_4_8_2.xml.expected
+> gen-idea dont-delete-existing-libs
+$ exists .idea/libraries/mysql_mysql_connector_java_5_1_25_runtime.xml
+$ exists .idea/libraries/SBT__javax_servlet_servlet_api_2_5_provided.xml
+$ exists .idea/libraries/SBT__junit_junit_4_8_2.xml
+> gen-idea
+$ exists .idea/libraries/mysql_mysql_connector_java_5_1_25_runtime.xml
+$ absent .idea/libraries/SBT__javax_servlet_servlet_api_2_5_provided.xml
+$ exists .idea/libraries/SBT__junit_junit_4_8_2.xml


### PR DESCRIPTION
sbt-idea should delete previously created xml files for libraries (matching `SBT__*.xml` pattern)
This can be very useful after upgrading some of the libraries.

This changes default behavior as it sounds reasonable for majority of use cases. New command argument `dont-delete-existing-libs` is added to enable the _old_ mode (i.e. add, but not delete)

thanks to @retronym for the idea (https://github.com/mpeltonen/sbt-idea/pull/253#issuecomment-26059033)
