### PR TITLE
Fixed descriptor generation for multiple root projects

### DIFF
--- a/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
+++ b/src/main/scala/org/sbtidea/SbtIdeaPlugin.scala
@@ -136,7 +136,7 @@ object SbtIdeaPlugin extends Plugin {
     for (subProj <- subProjects) {
       val buildDefinitionDir = new File(subProj.baseDir, "project")
       if (buildDefinitionDir.exists()) {
-        val sbtDef = new SbtProjectDefinitionIdeaModuleDescriptor(subProj.name, imlDir, subProj.baseDir,
+        val sbtDef = new SbtProjectDefinitionIdeaModuleDescriptor(subProj.name, imlDir, projectInfo.baseDir,
          buildDefinitionDir, sbtScalaVersion, sbtVersion, sbtOut, buildUnit.classpath, sbtModuleSourceFiles, state.log)
         if (args.contains(NoSbtBuildModule))
           sbtDef.removeIfExists()


### PR DESCRIPTION
This small change should fix issues #223 and #219.
Relative paths were generated using submodule baseDir, which resulted in paths like MODULE_DIR$/../ for EACH project descriptor. Now root project directory is used.

Tested it using sbt-test/sbt-idea/external-rootproject-dependency. Example:

![comparision](https://f.cloud.github.com/assets/6319267/1845227/204028c6-7579-11e3-9a89-f24c1a80d40a.png)
