### PR TITLE
Added support for extra test configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ Or in your Build.scala:
     lazy val myproject = Project(id = "XXXX" ....)
     .settings(ideaExcludeFolders := ".idea" :: ".idea_modules" :: Nil)
 
+### Include extra test configurations
+
+In your Build.scala:
+
+    lazy val LoadTest = config("test-load") extend Test
+    lazy val loadTestSettings : Seq[Setting[_]] = inConfig(LoadTest)(Defaults.testSettings ++ Seq(sourceDirectory in LoadTest <<= (sourceDirectory in LoadTest)(_ / ".." / "test-load")))
+
+    lazy val root = Project(...)
+      .settings(ideaExtraTestConfigurations := Seq(LoadTest) :: Nil)
+      .configs( LoadTest )
+      .settings( loadTestSettings : _*)
+
+
 
 
 TODO...

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SbtIdeaBuild extends Build with BuildExtra {
     sbtPlugin := true,
     organization := "com.github.mpeltonen",
     name := "sbt-idea",
-    version := "1.8.0-SNAPSHOT",
+    version := "1.7.0-SNAPSHOT",
     sbtVersion in Global := "0.13.0",
     scalaVersion in Global := "2.10.3",
     publishTo <<= version { (v: String) =>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object SbtIdeaBuild extends Build with BuildExtra {
     sbtPlugin := true,
     organization := "com.github.mpeltonen",
     name := "sbt-idea",
-    version := "1.7.0-SNAPSHOT",
+    version := "1.8.0-SNAPSHOT",
     sbtVersion in Global := "0.13.0",
     scalaVersion in Global := "2.10.3",
     publishTo <<= version { (v: String) =>

--- a/src/sbt-test/sbt-idea/with-extra-tests/.idea_modules/main.iml.expected
+++ b/src/sbt-test/sbt-idea/with-extra-tests/.idea_modules/main.iml.expected
@@ -1,0 +1,37 @@
+<module version="4" type="JAVA_MODULE">
+  <component name="FacetManager">
+    <facet name="Scala" type="scala">
+      <configuration>
+        <option name="compilerLibraryLevel" value="Project"></option>
+        <option name="compilerLibraryName" value="SBT: scala:2.10.2"></option>
+        <option name="languageLevel" value="Scala 2.10" />
+        <option name="fsc" value="true" />
+        <option name="compilerOptions" value=""/>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/../target/scala-2.10/classes"></output>
+    <output-test url="file://$MODULE_DIR$/../target/scala-2.10/test-classes"></output-test>
+    <exclude-output></exclude-output>
+    <content url="file://$MODULE_DIR$/../">
+      <sourceFolder url="file://$MODULE_DIR$/../src/main/scala" isTestSource="false"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/main/java" isTestSource="false"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/main/resources" isTestSource="false"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test/scala" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test/java" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/it/scala" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/it/java" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test-load/scala" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test-load/java" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test/resources" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/it/resources" isTestSource="true"></sourceFolder>
+      <sourceFolder url="file://$MODULE_DIR$/../src/test-load/resources" isTestSource="true"></sourceFolder>
+      <excludeFolder url="file://$MODULE_DIR$/../target"></excludeFolder>
+    </content>
+    <orderEntry type="inheritedJdk"></orderEntry>
+    <orderEntry type="sourceFolder" forTests="false"></orderEntry>
+    <orderEntry level="project" name="SBT: org.scala-lang:scala-library:2.10.2" type="library"></orderEntry>
+    <orderEntry level="project" name="SBT: junit:junit:4.8.2" type="library"></orderEntry>
+  </component>
+</module>

--- a/src/sbt-test/sbt-idea/with-extra-tests/project/Build.scala
+++ b/src/sbt-test/sbt-idea/with-extra-tests/project/Build.scala
@@ -1,0 +1,19 @@
+import org.sbtidea.test.util.AbstractScriptedTestBuild
+import sbt._
+import sbt.Keys._
+import org.sbtidea.SbtIdeaPlugin._
+
+object ScriptedTestBuild extends AbstractScriptedTestBuild("with-extra-tests") {
+  lazy val root = Project("main", file("."), settings = Defaults.defaultSettings ++ scriptedTestSettings ++ Seq(
+    libraryDependencies += "junit" % "junit" % "4.8.2",
+    ideaExtraTestConfigurations := Seq(LoadTest)
+  ))
+    .configs( IntegrationTest )
+    .settings( Defaults.itSettings : _*)
+    .configs( LoadTest)
+    .settings( loadTestSettings : _*)
+
+
+  lazy val LoadTest = config("test-load") extend Test
+  lazy val loadTestSettings : Seq[Setting[_]] = inConfig(LoadTest)(Defaults.testSettings ++ Seq(sourceDirectory in LoadTest <<= (sourceDirectory in LoadTest)(_ / ".." / "test-load")))
+}

--- a/src/sbt-test/sbt-idea/with-extra-tests/project/plugins.sbt
+++ b/src/sbt-test/sbt-idea/with-extra-tests/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.7.0-SNAPSHOT")
+

--- a/src/sbt-test/sbt-idea/with-extra-tests/test
+++ b/src/sbt-test/sbt-idea/with-extra-tests/test
@@ -1,0 +1,2 @@
+> gen-idea
+> assert-expected-xml-files


### PR DESCRIPTION
This change allows to add extra test configurations (for example load tests) so that the generated IDEA modules have correctly marked test source directories.
