### PR TITLE
Update Sonatype Snapshots url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Requirements
 ------------
 
-* [sbt](https://github.com/harrah/xsbt/wiki) 0.13
+* [sbt](https://github.com/sbt/sbt) 0.13
 * For sbt 0.12.x version of the plugin, see [branch sbt-0.12](https://github.com/mpeltonen/sbt-idea/tree/sbt-0.12#requirements)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following lines to ~/.sbt/0.13/plugins/build.sbt or PROJECT_DIR/project/
 
 To use the **latest snapshot** version, add also Sonatype snapshots repository resolver into the same **plugins.sbt** file:
 
-    resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+    resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
     addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.7.0-SNAPSHOT")
 


### PR DESCRIPTION
Sonatype snapshots now will only resolve over https.
Adjusted the README.md
