### PR TITLE
Handle zip files as jar files in library definitions

### DIFF
--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -67,7 +67,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
   private def libraryTableComponent(library: IdeaLibrary): xml.Node = {
     def makeUrl(file: File) = {
       val path = projectRelative(file)
-      val formatStr = if (path.endsWith(".jar")) "jar://%s!/" else "file://%s"
+      val formatStr = if (path.endsWith(".jar") || path.endsWith(".zip")) "jar://%s!/" else "file://%s"
       <root url={String.format(formatStr, path)}/>
     }
     <component name="libraryTable">


### PR DESCRIPTION
Intellij actually declares zip files as jar files - try to add zip sources to a library and then examine the resulting xml file.
