### PR TITLE
Upgrade Commons IO to a version that's a few years newer

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,7 @@ object SbtIdeaBuild extends Build with BuildExtra {
     ),
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
     libraryDependencies ++= Seq(
-      "commons-io" % "commons-io" % "2.0.1"
+      "commons-io" % "commons-io" % "2.4"
     )
   ) ++ addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "0.9.3" % "provided")
 


### PR DESCRIPTION
Play had to downgrade its version of commons-io to match the one specified here. I'd prefer if we didn't have to use such an old version
