### PR TITLE
JDK + language level autodetection (and other improvements)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,7 +31,7 @@ object SbtIdeaBuild extends Build with BuildExtra {
   ) ++ addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "0.9.3" % "provided")
 
 
-  def extraPom = (
+  def extraPom =
     <url>http://your.project.url</url>
     <licenses>
       <license>
@@ -50,5 +50,5 @@ object SbtIdeaBuild extends Build with BuildExtra {
       <name>Mikko Peltonen</name>
       <url>http://github.com/mpeltonen</url>
     </developer>
-  </developers>)
+  </developers>
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.5

--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -86,7 +86,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
   }
 
   private def projectRootManagerComponent: xml.Node =
-      <component name="ProjectRootManager" version="2" languageLevel={env.javaLanguageLevel.label} assert-keyword="true" jdk-15="true" project-jdk-name={env.projectJdkName.value} project-jdk-type="JavaSDK">
+      <component name="ProjectRootManager" version="2" languageLevel={env.javaLanguageLevel.value} assert-keyword="true" jdk-15="true" project-jdk-name={env.projectJdkName.version} project-jdk-type="JavaSDK">
         <output url="file://$PROJECT_DIR$/target/idea_output" />
       </component>
 

--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -123,7 +123,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
         "scala_compiler.xml" -> (if (env.useProjectFsc) Some(scalaCompilerXml) else None),
         "highlighting.xml" -> (if (env.enableTypeHighlighting) Some(highlightingXml) else None)
       ) foreach {
-        case (fileName, Some(xmlNode)) if (!configFile(fileName).exists) =>  saveFile(configDir, fileName, xmlNode)
+        case (fileName, Some(xmlNode)) if !configFile(fileName).exists =>  saveFile(configDir, fileName, xmlNode)
         case _ =>
       }
 
@@ -135,7 +135,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
       }
       for (ideaLib <- projectInfo.ideaLibs) {
         // MUST all be _
-        val filename = ideaLib.name.replaceAll("[:\\.\\s-]", "_") + ".xml"
+        val filename = ideaLib.name.replaceAll("[:\\.\\s/-]", "_") + ".xml"
         saveFile(librariesDir, filename, libraryTableComponent(ideaLib))
       }
 

--- a/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDescriptor.scala
@@ -86,7 +86,7 @@ class IdeaProjectDescriptor(val projectInfo: IdeaProjectInfo, val env: IdeaProje
   }
 
   private def projectRootManagerComponent: xml.Node =
-      <component name="ProjectRootManager" version="2" languageLevel={env.javaLanguageLevel} assert-keyword="true" jdk-15="true" project-jdk-name={env.projectJdkName} project-jdk-type="JavaSDK">
+      <component name="ProjectRootManager" version="2" languageLevel={env.javaLanguageLevel.label} assert-keyword="true" jdk-15="true" project-jdk-name={env.projectJdkName.value} project-jdk-type="JavaSDK">
         <output url="file://$PROJECT_DIR$/target/idea_output" />
       </component>
 

--- a/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
+++ b/src/main/scala/org/sbtidea/IdeaProjectDomain.scala
@@ -2,6 +2,8 @@ package org.sbtidea
 
 import android.AndroidSupport
 import java.io.File
+import org.sbtidea.ValueClasses.{JdkName, LanguageLevel}
+
 import xml.NodeSeq
 
 // cheating for now
@@ -62,7 +64,7 @@ case class IdeaProjectInfo(baseDir: File, name: String, childProjects: List[SubP
 
 case class IdeaUserEnvironment(webFacet: Boolean)
 
-case class IdeaProjectEnvironment(projectJdkName :String, javaLanguageLevel: String,
+case class IdeaProjectEnvironment(projectJdkName :JdkName, javaLanguageLevel: LanguageLevel,
                                   includeSbtProjectDefinitionModule: Boolean, projectOutputPath: Option[String],
                                   excludedFolders: Seq[String], compileWithIdea: Boolean, modulePath: String, useProjectFsc: Boolean,
                                   enableTypeHighlighting: Boolean, deleteExistingLibraries: Boolean)

--- a/src/main/scala/org/sbtidea/SystemProps.scala
+++ b/src/main/scala/org/sbtidea/SystemProps.scala
@@ -1,8 +1,10 @@
 package org.sbtidea
 
+import org.sbtidea.ValueClasses.JdkName
+
 object SystemProps {
-  val jdkName = System.getProperty("java.version").substring(0, 3)
-  val languageLevel = "JDK_" + jdkName.replace(".", "_")
+  val jdkName = JdkName(System.getProperty("java.version").substring(0, 3))
+  val languageLevel = ValueClasses.formatLanguageLevel(jdkName)
   val runsOnWindows = System.getProperty("os.name").contains("Windows")
   val userHome = {
     val system = System.getProperty("user.home")

--- a/src/main/scala/org/sbtidea/ValueClasses.scala
+++ b/src/main/scala/org/sbtidea/ValueClasses.scala
@@ -1,0 +1,25 @@
+package org.sbtidea
+
+import language.implicitConversions
+
+/**
+ * Date: 22/07/2014
+ * Time: 18:54
+ *
+ * @author Dan Sanduleac
+ */
+object ValueClasses {
+  case class LanguageLevel private(value: String) extends AnyVal
+
+  /** A Jdk name such as "1.8" */
+  class JdkName private(val version: String) extends AnyVal
+  object JdkName {
+    private[this] val Ver = """\d+\.\d+""".r
+    def apply(v: String): JdkName = v match {
+      case Ver() => new JdkName(v)
+      case _     => sys.error("Attempted to create JdkName with malformed value: " + v)
+    }
+  }
+
+  implicit def formatLanguageLevel(jdkName: JdkName) = LanguageLevel("JDK_" + jdkName.version.replace(".", "_"))
+}

--- a/src/main/scala/org/sbtidea/test/util/AbstractScriptedTestBuild.scala
+++ b/src/main/scala/org/sbtidea/test/util/AbstractScriptedTestBuild.scala
@@ -18,7 +18,7 @@ abstract class AbstractScriptedTestBuild(projectName : String) extends Build {
 
 	lazy val scriptedTestSettings = Seq(assertExpectedXmlFiles := assertXmlsTask)
 
-  private def assertXmlsTask {
+  private def assertXmlsTask() {
     val expectedFiles = listFiles(file("."), Array("expected"), true).asScala
     expectedFiles.map(assertExpectedXml).foldLeft[Option[String]](None) {
       (acc, fileResult) => if (acc.isDefined) acc else fileResult
@@ -78,12 +78,11 @@ abstract class AbstractScriptedTestBuild(projectName : String) extends Build {
   object WindowsPathRewriteRule extends RewriteRule {
     override def transform(n: Node): Seq[Node] =
       n match {
-        case e: Elem if (e.attributes.asAttrMap.values.exists(_.contains("\\"))) => {
+        case e: Elem if e.attributes.asAttrMap.values.exists(_.contains("\\")) =>
           e.copy(attributes = for (attr <- e.attributes) yield attr match {
             case a@Attribute(_, v, _) if v.text.contains("\\") => a.goodcopy(value = v.text.replaceAll("\\\\", "/"))
             case other => other
           })
-        }
         case _ => n
       }
   }
@@ -91,13 +90,12 @@ abstract class AbstractScriptedTestBuild(projectName : String) extends Build {
   object JDKVersionRewriteRule extends RewriteRule {
     override def transform(n: Node): Seq[Node] =
       n match {
-        case e: Elem if (e.attributes.asAttrMap.values.exists(_ == "ProjectRootManager")) => {
+        case e: Elem if e.attributes.asAttrMap.values.exists(_ == "ProjectRootManager") =>
           e.copy(attributes = for (attr <- e.attributes) yield attr match {
             case a@Attribute(k, _, _) if k == "languageLevel" => a.goodcopy(value = SystemProps.languageLevel)
             case a@Attribute(k, _, _) if k == "project-jdk-name" => a.goodcopy(value = SystemProps.jdkName)
             case other => other
           })
-        }
         case _ => n
       }
   }
@@ -121,9 +119,9 @@ abstract class AbstractScriptedTestBuild(projectName : String) extends Build {
   object IvyCachePathRewriteRule extends RewriteRule {
     override def transform(n: Node): Seq[Node] =
       n match {
-        case e: Elem if (e.attributes.asAttrMap.keys.exists(_ == "value")) => {
+        case e: Elem if e.attributes.asAttrMap.keys.exists(_ == "value") => {
           e.copy(attributes = for (attr <- e.attributes) yield attr match {
-            case a@Attribute(k, Text(v), _) if (k == "value" && v.contains("/.ivy2/")) => a.goodcopy(value = "~" + v.substring(v.indexOf("/.ivy2/")))
+            case a@Attribute(k, Text(v), _) if k == "value" && v.contains("/.ivy2/") => a.goodcopy(value = "~" + v.substring(v.indexOf("/.ivy2/")))
             case other => other
           })
         }

--- a/src/sbt-test/sbt-idea/dependency-with-classifier/project/build.properties
+++ b/src/sbt-test/sbt-idea/dependency-with-classifier/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0-RC1
+sbt.version=0.13.5


### PR DESCRIPTION
I noticed that, aside from some functionality for Android projects (which I don't use) the plugin doesn't make an effort to detect what JDK version and language level the sbt projects are using (instead it derives these from the JVM that sbt runs under, and sticks them onto the IDEA project). 

With this change, I look at `javacOptions` in each sbt project's scope, and if `-target` is set, I set the _SDK_ (specifically, the JDK library to use) and the _language level_ to that version. If, further, `-source` is also set, then I set the _language level_ to the version coming after `-source`.

Other improvements are minor source code rearrangements, things like that, but also a fix which allows slashes in ivy module names to be used (previously, they weren't normalized to `_` and the plugin would crash when it couldn't find the XML file with a slash in it, that it supposedly generated for a library whose name contained slashes).
