### PR TITLE
Upgrade to sbt 0.13.7 and sbt-pgp 1.0.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 libraryDependencies <+= sbtVersion("org.scala-sbt" % "scripted-plugin" % _)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
The old version of sbt-pgp has broken dependencies as described in
scala/community-builds#83.

This change should allow us to simplify Scala's community build config.
